### PR TITLE
Initial implementation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,19 @@
+---
+branches:
+  only:
+    - master
+sudo: required
+language: minimal
+matrix:
+  include:
+  - env: ELASTIC_STACK_VERSION=6.x
+  - env: ELASTIC_STACK_VERSION=7.10.0 # release pre introduction of deprecation logger
+  - env: ELASTIC_STACK_VERSION=7.x
+  - env: ELASTIC_STACK_VERSION=7.x SNAPSHOT=true
+  - env: ELASTIC_STACK_VERSION=8.x SNAPSHOT=true
+  fast_finish: true
+#allow_failures:
+#  - env: ELASTIC_STACK_VERSION=8.x SNAPSHOT=true
+#  - env: ELASTIC_STACK_VERSION=7.x SNAPSHOT=true
+install: ci/unit/docker-setup.sh
+script: ci/unit/docker-run.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ language: minimal
 matrix:
   include:
   - env: ELASTIC_STACK_VERSION=6.x
-  - env: ELASTIC_STACK_VERSION=7.10.0 # release pre introduction of deprecation logger
+  - env: ELASTIC_STACK_VERSION=7.10.1 # release pre introduction of :field_reference validator
   - env: ELASTIC_STACK_VERSION=7.x
   - env: ELASTIC_STACK_VERSION=7.x SNAPSHOT=true
   - env: ELASTIC_STACK_VERSION=8.x SNAPSHOT=true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,3 @@
+# v1.0.0
+
+ - Introduces plugin parameter validation adapters, including initial backport for `:field_reference` validator.

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,12 @@
+source 'https://rubygems.org'
+
+# Specify your gem's dependencies in logstash-mass_effect.gemspec
+gemspec
+
+logstash_path = ENV["LOGSTASH_PATH"] || "../../logstash"
+use_logstash_source = ENV["LOGSTASH_SOURCE"] && ENV["LOGSTASH_SOURCE"].to_s == "1"
+
+if Dir.exist?(logstash_path) && use_logstash_source
+  gem 'logstash-core', :path => "#{logstash_path}/logstash-core"
+  gem 'logstash-core-plugin-api', :path => "#{logstash_path}/logstash-core-plugin-api"
+end

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,13 @@
+Copyright (c) 2020 Elastic N.V. <http://www.elastic.co>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,58 @@
 # Validator Support Mixin
+
+This gem provides back-ports of new validators that have been added to Logstash
+core. By using this support adapter, plugin developers can use newly-introduced
+validators without constraining the versions of Logstash on which their plugin
+can run.
+
+When a plugin using this adapter runs on a version of Logstash that does _not_
+provide the named validator, the back-ported validator provided by this adapter
+is used instead.
+
+## Usage
+
+1. Add this gem as a runtime dependency of your plugin. To avoid conflicts with
+   other plugins, you should always use the [pessimistic operator][] `~>` to
+   match the minimum `1.x` that provides the back-ports you intend to use:
+
+    ~~~ ruby
+    Gem::Specification.new do |s|
+      # ...
+
+      s.add_runtime_dependency 'logstash-mixin-validator_support', '~>1.0'
+    end
+    ~~~
+
+2. In your plugin code, require this library and extend one or more of the
+   provided validators into your plugin. For example, to use the
+   `:field_reference` validator introduced in Logstash 7.11:
+
+    ~~~ ruby
+    require 'logstash/plugin_mixins/validator_support/field_reference_validation_adapter'
+
+    class LogStash::Inputs::Foo < Logstash::Inputs::Base
+      extend LogStash::PluginMixins::ValidatorSupport::FieldReferenceValidationAdapter
+
+      # ...
+    end
+    ~~~
+
+3. Use the validator as normal when defining config options; your plugin does
+   not need to know whether the validator was provided by Logstash core or by
+   this gem.
+
+    ~~~ ruby
+      config :target, :validate => :field_reference
+    ~~~
+
+## Development
+
+This gem:
+ - *MUST* remain API-stable at 1.x
+ - *MUST NOT* introduce additional runtime dependencies
+
+When developing back-ports, sometimes it may not be possible to provide a
+verbatim validation. In these cases, developers should err on the side of the
+back-port accepting input that the core implementation may consider invalid.
+
+[pessimistic operator]: https://thoughtbot.com/blog/rubys-pessimistic-operator

--- a/ci/unit/Dockerfile
+++ b/ci/unit/Dockerfile
@@ -1,9 +1,10 @@
 ARG ELASTIC_STACK_VERSION
-FROM docker.elastic.co/logstash/logstash:$ELASTIC_STACK_VERSION
+ARG DISTRIBUTION_SUFFIX
+FROM docker.elastic.co/logstash/logstash${DISTRIBUTION_SUFFIX}:${ELASTIC_STACK_VERSION}
 COPY --chown=logstash:logstash Gemfile /usr/share/plugins/plugin/Gemfile
 COPY --chown=logstash:logstash *.gemspec /usr/share/plugins/plugin/
 RUN cp /usr/share/logstash/logstash-core/versions-gem-copy.yml /usr/share/logstash/versions.yml
-ENV PATH="${PATH}:/usr/share/logstash/vendor/jruby/bin"
+ENV PATH="${PATH}:/usr/share/logstash/vendor/jruby/bin:/usr/share/logstash/jdk/bin"
 ENV LOGSTASH_SOURCE="1"
 ENV ELASTIC_STACK_VERSION=$ELASTIC_STACK_VERSION
 # DISTRIBUTION="default" (by default) or "oss"

--- a/ci/unit/Dockerfile
+++ b/ci/unit/Dockerfile
@@ -1,0 +1,18 @@
+ARG ELASTIC_STACK_VERSION
+FROM docker.elastic.co/logstash/logstash:$ELASTIC_STACK_VERSION
+COPY --chown=logstash:logstash Gemfile /usr/share/plugins/plugin/Gemfile
+COPY --chown=logstash:logstash *.gemspec /usr/share/plugins/plugin/
+RUN cp /usr/share/logstash/logstash-core/versions-gem-copy.yml /usr/share/logstash/versions.yml
+ENV PATH="${PATH}:/usr/share/logstash/vendor/jruby/bin"
+ENV LOGSTASH_SOURCE="1"
+ENV ELASTIC_STACK_VERSION=$ELASTIC_STACK_VERSION
+# DISTRIBUTION="default" (by default) or "oss"
+ARG DISTRIBUTION
+ENV DISTRIBUTION=$DISTRIBUTION
+# INTEGRATION="true" while integration testing (false-y by default)
+ARG INTEGRATION
+ENV INTEGRATION=$INTEGRATION
+RUN gem install bundler -v '< 2'
+WORKDIR /usr/share/plugins/plugin
+RUN bundle install --with test ci
+COPY --chown=logstash:logstash . /usr/share/plugins/plugin

--- a/ci/unit/docker-compose.yml
+++ b/ci/unit/docker-compose.yml
@@ -1,0 +1,20 @@
+version: '3'
+
+# run tests:  cd ci/unit; docker-compose up --build --force-recreate
+# manual:  cd ci/unit; docker-compose run logstash bash
+services:
+
+  logstash:
+    build:
+      context: ../../
+      dockerfile: ci/unit/Dockerfile
+      args:
+        - ELASTIC_STACK_VERSION=$ELASTIC_STACK_VERSION
+        - DISTRIBUTION=${DISTRIBUTION:-default}
+        #- INTEGRATION=false
+    command: ci/unit/run.sh
+    env_file: docker.env
+    environment:
+      - SPEC_OPTS
+      #- JRUBY_OPTS
+    tty: true

--- a/ci/unit/docker-run.sh
+++ b/ci/unit/docker-run.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# This is intended to be run inside the docker container as the command of the docker-compose.
+set -ex
+
+CURRENT_DIR=$(dirname "${BASH_SOURCE[0]}")
+
+docker-compose -f $CURRENT_DIR/docker-compose.yml up --exit-code-from logstash

--- a/ci/unit/docker-setup.sh
+++ b/ci/unit/docker-setup.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+
+# This is intended to be run the plugin's root directory. `ci/unit/docker-test.sh`
+# Ensure you have Docker installed locally and set the ELASTIC_STACK_VERSION environment variable.
+set -e
+
+VERSION_URL="https://raw.githubusercontent.com/elastic/logstash/master/ci/logstash_releases.json"
+
+if [ -z "${ELASTIC_STACK_VERSION}" ]; then
+    echo "Please set the ELASTIC_STACK_VERSION environment variable"
+    echo "For example: export ELASTIC_STACK_VERSION=7.x"
+    exit 1
+fi
+
+echo "Fetching versions from $VERSION_URL"
+VERSIONS=$(curl $VERSION_URL)
+
+if [[ "$SNAPSHOT" = "true" ]]; then
+  ELASTIC_STACK_RETRIEVED_VERSION=$(echo $VERSIONS | jq '.snapshots."'"$ELASTIC_STACK_VERSION"'"')
+  echo $ELASTIC_STACK_RETRIEVED_VERSION
+else
+  ELASTIC_STACK_RETRIEVED_VERSION=$(echo $VERSIONS | jq '.releases."'"$ELASTIC_STACK_VERSION"'"')
+fi
+
+if [[ "$ELASTIC_STACK_RETRIEVED_VERSION" != "null" ]]; then
+  # remove starting and trailing double quotes
+  ELASTIC_STACK_RETRIEVED_VERSION="${ELASTIC_STACK_RETRIEVED_VERSION%\"}"
+  ELASTIC_STACK_RETRIEVED_VERSION="${ELASTIC_STACK_RETRIEVED_VERSION#\"}"
+  echo "Translated $ELASTIC_STACK_VERSION to ${ELASTIC_STACK_RETRIEVED_VERSION}"
+  export ELASTIC_STACK_VERSION=$ELASTIC_STACK_RETRIEVED_VERSION
+fi
+
+if [[ "$DISTRIBUTION" = "oss" ]]; then
+  DISTRIBUTION_SUFFIX="-oss"
+else
+  DISTRIBUTION_SUFFIX=""
+fi
+
+echo "Testing against version: $ELASTIC_STACK_VERSION (distribution: ${DISTRIBUTION:-"default"})"
+
+if [[ "$ELASTIC_STACK_VERSION" = *"-SNAPSHOT" ]]; then
+    cd /tmp
+
+    jq=".build.projects.\"logstash\".packages.\"logstash$DISTRIBUTION_SUFFIX-$ELASTIC_STACK_VERSION-docker-image.tar.gz\".url"
+    result=$(curl --silent https://artifacts-api.elastic.co/v1/versions/$ELASTIC_STACK_VERSION/builds/latest | jq -r $jq)
+    echo $result
+    curl $result > logstash-docker-image.tar.gz
+    tar xfvz logstash-docker-image.tar.gz repositories
+    echo "Loading docker image: "
+    cat repositories
+    docker load < logstash-docker-image.tar.gz
+    rm logstash-docker-image.tar.gz
+    cd -
+fi
+
+if [ -f Gemfile.lock ]; then
+    rm Gemfile.lock
+fi
+
+CURRENT_DIR=$(dirname "${BASH_SOURCE[0]}") # e.g. "ci/unit"
+
+docker-compose -f "$CURRENT_DIR/docker-compose.yml" down
+docker-compose -f "$CURRENT_DIR/docker-compose.yml" build logstash
+
+#docker-compose -f "$CURRENT_DIR/docker-compose.yml" up --exit-code-from logstash --force-recreate

--- a/ci/unit/docker.env
+++ b/ci/unit/docker.env
@@ -1,0 +1,6 @@
+#LS_JAVA_OPTS="-Xms256m -Xmx256m -XX:MaxMetaspaceSize=256m"
+# Common LS options (can be overridden from ENV e.g. in .travis.yml) :
+# - `-Xregexp.interruptible=true -Xcompile.invokedynamic=true -Xjit.threshold=0` LS base-line
+# - `-XX:+UseParallelGC` do not use G1 (default) on Java 11
+# - `-v -W1` print JRuby version but do not go verbose
+JRUBY_OPTS=-Xregexp.interruptible=true -Xcompile.invokedynamic=true -Xjit.threshold=0 -J-XX:+UseParallelGC -J-XX:+PrintCommandLineFlags -v -W1

--- a/ci/unit/run.sh
+++ b/ci/unit/run.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# This is intended to be run inside the docker container as the command of the docker-compose.
+
+env
+
+set -ex
+
+jruby -rbundler/setup -S rspec -fd

--- a/lib/logstash/plugin_mixins/validator_support.rb
+++ b/lib/logstash/plugin_mixins/validator_support.rb
@@ -2,7 +2,6 @@
 
 require 'logstash/version'
 require 'logstash/namespace'
-require 'logstash/plugin'
 
 module LogStash
   module PluginMixins

--- a/lib/logstash/plugin_mixins/validator_support.rb
+++ b/lib/logstash/plugin_mixins/validator_support.rb
@@ -1,0 +1,101 @@
+# encoding: utf-8
+
+require 'logstash/version'
+require 'logstash/namespace'
+require 'logstash/plugin'
+
+module LogStash
+  module PluginMixins
+    module ValidatorSupport
+
+      ##
+      # @api internal
+      #
+      # @param base [#validate_value]
+      # @param validator_name [Symbol]
+      def self.native?(base, validator_name)
+        native_is_valid, native_coerced_or_error = base.validate_value(nil, validator_name)
+
+        native_is_valid || !native_coerced_or_error.start_with?('Unknown validator')
+      end
+
+      ##
+      # A NamedValidationAdapter is a module that can be mixed into a Logstash
+      # plugin to ensure the named validator is present and available, whether
+      # provided by Logstash core or approximated with the provided backport
+      # implementation.
+      #
+      # @api internal
+      #
+      class NamedValidationAdapter < Module
+        ##
+        # Create a new named validation adapter, to approximate the implementation
+        # of a named validation that exists in Logstash Core.
+        #
+        # @api private
+        #
+        # @param validator_name [Symbol]
+        # @yieldparam value [Hash,Array]
+        # @yieldreturn [true, Object]:  validation success returns true with coerced value (see: ValidationResult#success)
+        # @yieldreturn [false, String]: validation failure returns false with error message (see: ValidationResult#failure)
+        def initialize(validator_name, &validator_implementation)
+          fail(ArgumentError, '`validator_name` must be a Symbol')         unless validator_name.kind_of?(Symbol)
+          fail(ArgumentError, '`validator_implementation` block required') unless validator_implementation
+
+          define_singleton_method(:validate, &validator_implementation)
+          define_singleton_method(:name) { "#{NamedValidationAdapter}(#{validator_name})" }
+
+          define_singleton_method(:extended) do |base|
+            # Only include the interceptor if support is not natively provided.
+            unless ValidatorSupport.native?(base, validator_name)
+              interceptor = NamedValidationInterceptor.new(validator_name, self)
+              base.extend(interceptor)
+            end
+          end
+        end
+      end
+
+      ##
+      # A NamedValidationInterceptor intercepts requests to validate input with the given
+      # name and instead substitutes its own implementation. This implementation will
+      # override Logstash core functionality.
+      #
+      # @api private
+      #
+      class NamedValidationInterceptor < Module
+        ##
+        # @param validator_name [Symbol]
+        # @param validator [#validate]
+        def initialize(validator_name, validator)
+          fail(ArgumentError, '`validator_name` must be a Symbol')          unless validator_name.kind_of?(Symbol)
+          fail(ArgumentError, '`validator` must respond to `\#{validate}`') unless validator.respond_to?(:validate)
+
+          define_method(:validate_value) do |value, required_validator|
+            if required_validator != validator_name
+              super(value, required_validator)
+            else
+              value = deep_replace(value)
+              value = hash_or_array(value)
+
+              validator.validate(value)
+            end
+          end
+
+          define_singleton_method(:name) { "#{NamedValidationInterceptor}(#{validator_name})" }
+        end
+      end
+
+      ##
+      # Helper functions for returning success and failure tuples
+      module ValidationResult
+        def self.success(coerced_value)
+          [true, coerced_value]
+        end
+
+        def self.failure(error_message)
+          [false, error_message]
+        end
+      end
+    end
+  end
+end

--- a/lib/logstash/plugin_mixins/validator_support/field_reference_validation_adapter.rb
+++ b/lib/logstash/plugin_mixins/validator_support/field_reference_validation_adapter.rb
@@ -1,0 +1,29 @@
+# encoding: utf-8
+
+require 'logstash/plugin_mixins/validator_support'
+
+module LogStash
+  module PluginMixins
+    module ValidatorSupport
+      field_name = /[^\[\]]+/                                     # anything but brackets
+      path_fragment = /\[#{field_name}\]/                         # bracket-wrapped field name
+      field_reference_literal = /#{path_fragment}+/               # one or more path fragments
+      embedded_field_reference = /\[#{field_reference_literal}\]/ # bracket-wrapped field reference literal
+      composite_field_reference = /#{Regexp.union(path_fragment, embedded_field_reference)}+/
+
+      # anchored pattern matching either a stand-alone field name, or a composite field reference
+      field_reference_pattern = /\A#{Regexp.union(field_name,composite_field_reference)}\z/
+
+      FieldReferenceValidationAdapter = NamedValidationAdapter.new(:field_reference) do |value|
+        break ValidationResult.failure("Expected exactly one field reference, got `#{value.inspect}`") unless value.kind_of?(Array) && value.size <= 1
+        break ValidationResult.success(nil) if value.empty? || value.first.nil?
+
+        candidate = value.first
+
+        break ValidationResult.failure("Expected a valid field reference, got `#{candidate.inspect}`") unless field_reference_pattern =~ candidate
+
+        break ValidationResult.success(candidate)
+      end
+    end
+  end
+end

--- a/logstash-mixin-validator_support.gemspec
+++ b/logstash-mixin-validator_support.gemspec
@@ -18,4 +18,5 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'logstash-core', '>= 5.0.0'
 
   s.add_development_dependency 'rspec', '~> 3.9'
+  s.add_development_dependency 'logstash-devutils'
 end

--- a/logstash-mixin-validator_support.gemspec
+++ b/logstash-mixin-validator_support.gemspec
@@ -1,0 +1,21 @@
+Gem::Specification.new do |s|
+  s.name          = 'logstash-mixin-validator_support'
+  s.version       = '1.0.0'
+  s.licenses      = %w(Apache-2.0)
+  s.summary       = "Support for the plugin parameter validations introduced in recent releases of Logstash, for plugins wishing to use them on older Logstashes"
+  s.description   = "This gem is meant to be a dependency of any Logstash plugin that wishes to use validators introduced in recent versions of Logstash while maintaining backward-compatibility with earlier Logstashes. When used on older Logstash versions, it provides back-ports of the new validators."
+  s.authors       = %w(Elastic)
+  s.email         = 'info@elastic.co'
+  s.homepage      = 'https://github.com/logstash-plugins/logstash-mixin-validator_support'
+  s.require_paths = %w(lib)
+
+  s.files = %w(lib spec vendor).flat_map{|dir| Dir.glob("#{dir}/**/*")}+Dir.glob(["*.md","LICENSE"])
+
+  s.test_files = s.files.grep(%r{^(test|spec|features)/})
+
+  s.platform = RUBY_PLATFORM
+
+  s.add_runtime_dependency 'logstash-core', '>= 5.0.0'
+
+  s.add_development_dependency 'rspec', '~> 3.9'
+end

--- a/spec/logstash/plugin_mixins/validator_support/field_reference_validation_adapter_spec.rb
+++ b/spec/logstash/plugin_mixins/validator_support/field_reference_validation_adapter_spec.rb
@@ -1,0 +1,52 @@
+# encoding: utf-8
+
+require 'logstash/plugin_mixins/validator_support/field_reference_validation_adapter'
+
+describe LogStash::PluginMixins::ValidatorSupport::FieldReferenceValidationAdapter do
+  it 'is an instance of NamedValidationAdapter' do
+    expect(described_class).to be_a_kind_of LogStash::PluginMixins::ValidatorSupport::NamedValidationAdapter
+  end
+
+  context '#validate' do
+    [
+      ['@timestamp'],
+      ['[@timestamp]'],
+      ['[@metadata][ssl]'],
+      ['[link][0]'],
+      ['one'],
+      ['[fruit][[bananas][oranges]]'],
+      [],
+      [nil]
+    ].each do |candidate|
+      context "valid input `#{candidate.inspect}`" do
+        it 'correctly reports the value as valid', :aggregate_failures do
+          is_valid_result, coerced_or_error = described_class.validate(candidate)
+
+          expect(is_valid_result).to be true
+          expect(coerced_or_error).to eq candidate.first
+        end
+      end
+    end
+
+    [
+      ['link[0]'],
+      ['][N\\//\\L][D'],
+      ["one","two"],
+      {"this" => "that"},
+      ['[fruit][bananas[oranges]]'],
+    ].each do |candidate|
+      let(:candidate) { candidate }
+
+      context "invalid input `#{candidate.inspect}`" do
+        it 'correctly reports the value as invalid', :aggregate_failures do
+          is_valid_result, coerced_or_error = described_class.validate(candidate)
+
+          expect(is_valid_result).to be false
+          expect(coerced_or_error).to be_a_kind_of String
+          expect(coerced_or_error).to_not include('Unknown validator')
+          expect(coerced_or_error).to include('field reference')
+        end
+      end
+    end
+  end
+end

--- a/spec/logstash/plugin_mixins/validator_support_spec.rb
+++ b/spec/logstash/plugin_mixins/validator_support_spec.rb
@@ -1,0 +1,53 @@
+# encoding: utf-8
+
+require 'logstash/plugin_mixins/validator_support'
+
+require 'logstash/namespace'
+require 'logstash/plugin'
+
+require 'securerandom'
+
+describe LogStash::PluginMixins::ValidatorSupport::NamedValidationAdapter do
+  context 'an adapter re-defining a named validator that exists in Logstash core' do
+    let(:adapter) { described_class.new(:string) { |value| [false, 'intentional failure'] } }
+    let(:plugin_class) { Class.new(LogStash::Plugin) }
+    before(:each) { plugin_class.extend(adapter) }
+    context '#validate_value' do
+      it 'does not intercept validation' do
+        expect(adapter).to_not receive(:validate)
+
+        result = plugin_class.validate_value("banana", :string)
+
+        expect(result).to be_a_kind_of(Array)
+        expect(result.size).to eq(2)
+
+        expect(result[0]).to eq true
+        expect(result[1]).to eq 'banana'
+      end
+    end
+  end
+
+  context 'an adapter defining a named validator that does not exist in Logstash core' do
+    let(:validator_name) { "some_custom_validator_name_#{SecureRandom.hex(10)}".to_sym }
+    let(:adapter) { described_class.new(validator_name) { |value| [false, 'intentional failure'] } }
+    let(:plugin_class) { Class.new(LogStash::Plugin) }
+    before(:each) { plugin_class.extend(adapter) }
+    
+    context '#validate_value' do
+      it 'intercepts validation' do
+        expect(plugin_class).to receive(:hash_or_array).and_call_original
+        expect(plugin_class).to receive(:deep_replace).and_call_original
+
+        expect(adapter).to receive(:validate).with(["banana"]).and_call_original
+
+        result = plugin_class.validate_value("banana", validator_name)
+
+        expect(result).to be_a_kind_of(Array)
+        expect(result.size).to eq(2)
+
+        expect(result[0]).to eq false
+        expect(result[1]).to eq 'intentional failure'
+      end
+    end
+  end
+end

--- a/spec/logstash/plugin_mixins/validator_support_spec.rb
+++ b/spec/logstash/plugin_mixins/validator_support_spec.rb
@@ -1,9 +1,8 @@
 # encoding: utf-8
 
-require 'logstash/plugin_mixins/validator_support'
+require "logstash/devutils/rspec/spec_helper"
 
-require 'logstash/namespace'
-require 'logstash/plugin'
+require 'logstash/plugin_mixins/validator_support'
 
 require 'securerandom'
 


### PR DESCRIPTION
Introduces an internal API `NamedValidationAdapter`, instances of which can be
mixed into a Logstash plugin to ensure that the named validator exists. When
validating, the implementation from Logstash core is used whenever available,
and the provided backport is used only when necessary. This allows backports to
approximate upstream functionality, which in turn frees new validators
intrroduced in Logstash core from constraints.

Using this API, this PR also introduces  `FieldReferenceValidationAdapter`, an
adapter providing an approximation to the `:field_reference` named validator
proposed in [elastic/logstash#12459][].

Using this pattern, we will be free to begin introducing more validators to
Logstash core, absorbing some of the [bespoke validators][] introduced
in plugin projects.

[elastic/logstash#12459]: https://github.com/elastic/logstash/pull/12459
[bespoke validators]: https://github.com/logstash-plugins/logstash-input-elasticsearch/blob/v4.8.1/lib/logstash/inputs/elasticsearch.rb#L440-L477