### PR TITLE
Fix: '' value behavior in field_reference validator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
-# v1.0.0
+# 1.1.0
+
+ - Fix: '' value behavior in `field_reference` validator [#2](https://github.com/logstash-plugins/logstash-mixin-validator_support/pull/2)
+
+# 1.0.1
 
  - Introduces plugin parameter validation adapters, including initial backport for `:field_reference` validator.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 1.0.1
+# 1.0.2
 
  - Fix: '' value behavior in `field_reference` validator [#2](https://github.com/logstash-plugins/logstash-mixin-validator_support/pull/2)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 1.1.0
+# 1.0.1
 
  - Fix: '' value behavior in `field_reference` validator [#2](https://github.com/logstash-plugins/logstash-mixin-validator_support/pull/2)
 

--- a/lib/logstash/plugin_mixins/validator_support/field_reference_validation_adapter.rb
+++ b/lib/logstash/plugin_mixins/validator_support/field_reference_validation_adapter.rb
@@ -16,9 +16,11 @@ module LogStash
 
       FieldReferenceValidationAdapter = NamedValidationAdapter.new(:field_reference) do |value|
         break ValidationResult.failure("Expected exactly one field reference, got `#{value.inspect}`") unless value.kind_of?(Array) && value.size <= 1
-        break ValidationResult.success(nil) if value.empty? || value.first.nil?
 
         candidate = value.first
+
+        break ValidationResult.success(nil) if value.empty? || candidate.nil?
+        break ValidationResult.success(candidate) if candidate.empty? # compatibility with LS >= 7.x field_reference validation logic
 
         break ValidationResult.failure("Expected a valid field reference, got `#{candidate.inspect}`") unless field_reference_pattern =~ candidate
 

--- a/lib/logstash/plugin_mixins/validator_support/field_reference_validation_adapter.rb
+++ b/lib/logstash/plugin_mixins/validator_support/field_reference_validation_adapter.rb
@@ -19,8 +19,7 @@ module LogStash
 
         candidate = value.first
 
-        break ValidationResult.success(nil) if value.empty? || candidate.nil?
-        break ValidationResult.success(candidate) if candidate.empty? # compatibility with LS >= 7.x field_reference validation logic
+        break ValidationResult.success(nil) if value.empty? || candidate.nil? || candidate.empty?
 
         break ValidationResult.failure("Expected a valid field reference, got `#{candidate.inspect}`") unless field_reference_pattern =~ candidate
 

--- a/logstash-mixin-validator_support.gemspec
+++ b/logstash-mixin-validator_support.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name          = 'logstash-mixin-validator_support'
-  s.version       = '1.0.1'
+  s.version       = '1.1.0'
   s.licenses      = %w(Apache-2.0)
   s.summary       = "Support for the plugin parameter validations introduced in recent releases of Logstash, for plugins wishing to use them on older Logstashes"
   s.description   = "This gem is meant to be a dependency of any Logstash plugin that wishes to use validators introduced in recent versions of Logstash while maintaining backward-compatibility with earlier Logstashes. When used on older Logstash versions, it provides back-ports of the new validators."

--- a/logstash-mixin-validator_support.gemspec
+++ b/logstash-mixin-validator_support.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name          = 'logstash-mixin-validator_support'
-  s.version       = '1.0.1'
+  s.version       = '1.0.2'
   s.licenses      = %w(Apache-2.0)
   s.summary       = "Support for the plugin parameter validations introduced in recent releases of Logstash, for plugins wishing to use them on older Logstashes"
   s.description   = "This gem is meant to be a dependency of any Logstash plugin that wishes to use validators introduced in recent versions of Logstash while maintaining backward-compatibility with earlier Logstashes. When used on older Logstash versions, it provides back-ports of the new validators."

--- a/logstash-mixin-validator_support.gemspec
+++ b/logstash-mixin-validator_support.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name          = 'logstash-mixin-validator_support'
-  s.version       = '1.1.0'
+  s.version       = '1.0.1'
   s.licenses      = %w(Apache-2.0)
   s.summary       = "Support for the plugin parameter validations introduced in recent releases of Logstash, for plugins wishing to use them on older Logstashes"
   s.description   = "This gem is meant to be a dependency of any Logstash plugin that wishes to use validators introduced in recent versions of Logstash while maintaining backward-compatibility with earlier Logstashes. When used on older Logstash versions, it provides back-ports of the new validators."

--- a/spec/logstash/plugin_mixins/validator_support/field_reference_validation_adapter_spec.rb
+++ b/spec/logstash/plugin_mixins/validator_support/field_reference_validation_adapter_spec.rb
@@ -28,6 +28,16 @@ describe LogStash::PluginMixins::ValidatorSupport::FieldReferenceValidationAdapt
       end
     end
 
+    context "valid input `''`" do
+      # failed in version 1.0.x which was not compatible with LS 7.x behavior
+      it 'correctly reports the value as valid' do
+        is_valid_result, coerced_or_error = described_class.validate ['']
+
+        expect(is_valid_result).to be true
+        expect(coerced_or_error).to eql ''
+      end
+    end
+
     [
       ['link[0]'],
       ['][N\\//\\L][D'],

--- a/spec/logstash/plugin_mixins/validator_support/field_reference_validation_adapter_spec.rb
+++ b/spec/logstash/plugin_mixins/validator_support/field_reference_validation_adapter_spec.rb
@@ -34,7 +34,7 @@ describe LogStash::PluginMixins::ValidatorSupport::FieldReferenceValidationAdapt
         is_valid_result, coerced_or_error = described_class.validate ['']
 
         expect(is_valid_result).to be true
-        expect(coerced_or_error).to eql ''
+        expect(coerced_or_error).to be nil
       end
     end
 


### PR DESCRIPTION
Maintain compatibility with LS 7.x on LS 6.x when an empty value is passed to a field_reference validator, sample use-case:

- `config :headers_target, :validate => :field_reference`
- `described_class.new("headers_target" => '')` leads to a validation error when the mixin implementation is used (on 6.x)


this incompatibility surfaced at https://github.com/logstash-plugins/logstash-input-imap/pull/55 :red_circle: [failing 6.x build](https://app.travis-ci.com/github/logstash-plugins/logstash-input-imap/jobs/550126336#L488-L496)