### PR TITLE
IPv4|IPv6|host with optional port pair validator added.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 1.1.0
-  - Introduces `:host_port_pair` validator [#4](https://github.com/logstash-plugins/logstash-mixin-validator_support/pull/4)
+  - Introduces `:required_host_optional_port` validator [#4](https://github.com/logstash-plugins/logstash-mixin-validator_support/pull/4)
 
 ## 1.0.2
   - Fix: '' value behavior in `field_reference` validator [#2](https://github.com/logstash-plugins/logstash-mixin-validator_support/pull/2)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
-# 1.0.2
+## 1.1.0
+  - Introduces `:host_port_pair` validator [#4](https://github.com/logstash-plugins/logstash-mixin-validator_support/pull/4)
 
- - Fix: '' value behavior in `field_reference` validator [#2](https://github.com/logstash-plugins/logstash-mixin-validator_support/pull/2)
+## 1.0.2
+  - Fix: '' value behavior in `field_reference` validator [#2](https://github.com/logstash-plugins/logstash-mixin-validator_support/pull/2)
 
-# 1.0.1
-
- - Introduces plugin parameter validation adapters, including initial backport for `:field_reference` validator.
+## 1.0.1
+  - Introduces plugin parameter validation adapters, including initial backport for `:field_reference` validator.

--- a/lib/logstash/plugin_mixins/validator_support/required_host_optional_port_validation_adapter.rb
+++ b/lib/logstash/plugin_mixins/validator_support/required_host_optional_port_validation_adapter.rb
@@ -1,0 +1,58 @@
+# encoding: utf-8
+
+require 'logstash/plugin_mixins/validator_support'
+
+require 'resolv'
+
+module LogStash
+  module PluginMixins
+    module ValidatorSupport
+
+
+      # rely on Resolv's IPv4#create and IPv6#create to validate IP addresses, but first regex to avoid most exceptions
+      is_valid_ipv4 = ->(candidate) { Resolv::IPv4::Regex.match?(candidate) && Resolv::IPv4.create(candidate) rescue false}
+      is_valid_ipv6 = ->(candidate) { Resolv::IPv6::Regex.match?(candidate) && Resolv::IPv6.create(candidate) rescue false}
+
+      is_valid_hostname = ->(candidate) { (%r{\A([a-z0-9]+(-[a-z0-9]+)*\.)+[a-z]{2,}\Z}i).match?(candidate) }
+
+      # the normalized tuple from valid values
+      host_port_pair = Struct.new(:host, :port)
+
+      expectation_desc = "required-host optional-port pair"
+
+      port_range = Range.new(0,65535)
+
+      ##
+      # When included into a Logstash plugin, adds a valiador named `required_host_optional_port`, which expects
+      # exactly one string matching a required host, optionally followed by a colon and a port number, and coerces
+      # valid values into a value with `host` and `port` attributes.
+      # When specifying an IPv6 address, it MUST be enclosed in square-brackets, and the address itself (without
+      # brackets) will be made available in the coerced value's `host` attribute
+      RequiredHostOptionalPortValidationAdapter = NamedValidationAdapter.new(:required_host_optional_port) do |value|
+        break ValidationResult.failure("Expected exactly one #{expectation_desc}, got `#{value.inspect}`") unless value.kind_of?(Array) && value.size <= 1
+
+        candidate = value.first
+
+        break ValidationResult.failure("Expected a valid #{expectation_desc}, got `#{candidate.inspect}`") unless candidate.kind_of?(String) && !candidate.empty?
+
+        # optional port
+        candidate_host, candidate_port = candidate.split(%r{\:(?=\d{1,5}\z)},2)
+        port = candidate_port&.to_i
+
+        break ValidationResult.failure("Expected a port in #{port_range.inspect}, got `#{port}`") if port && !port_range.include?(port)
+
+        # bracket-wrapped ipv6
+        if candidate_host.start_with?('[') && candidate_host.end_with?(']')
+          candidate_host = candidate_host[1...-1]
+          break ValidationResult.success(host_port_pair.new(candidate_host, port)) if is_valid_ipv6[candidate_host]
+        else
+          # ipv4 or hostname
+          break ValidationResult.success(host_port_pair.new(candidate_host, port)) if is_valid_ipv4[candidate_host]
+          break ValidationResult.success(host_port_pair.new(candidate_host, port)) if is_valid_hostname[candidate_host]
+        end
+
+        break ValidationResult.failure("Expected a valid #{expectation_desc}, got `#{candidate.inspect}`")
+      end
+    end
+  end
+end

--- a/logstash-mixin-validator_support.gemspec
+++ b/logstash-mixin-validator_support.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name          = 'logstash-mixin-validator_support'
-  s.version       = '1.0.2'
+  s.version       = '1.1.0'
   s.licenses      = %w(Apache-2.0)
   s.summary       = "Support for the plugin parameter validations introduced in recent releases of Logstash, for plugins wishing to use them on older Logstashes"
   s.description   = "This gem is meant to be a dependency of any Logstash plugin that wishes to use validators introduced in recent versions of Logstash while maintaining backward-compatibility with earlier Logstashes. When used on older Logstash versions, it provides back-ports of the new validators."

--- a/spec/logstash/plugin_mixins/validator_support/required_host_optional_port_validation_adapter_spec.rb
+++ b/spec/logstash/plugin_mixins/validator_support/required_host_optional_port_validation_adapter_spec.rb
@@ -1,0 +1,74 @@
+# encoding: utf-8
+
+require 'logstash/plugin_mixins/validator_support/required_host_optional_port_validation_adapter'
+
+describe LogStash::PluginMixins::ValidatorSupport::RequiredHostOptionalPortValidationAdapter do
+
+  it 'is an instance of NamedValidationAdapter' do
+    expect(described_class).to be_a_kind_of LogStash::PluginMixins::ValidatorSupport::NamedValidationAdapter
+  end
+
+  context '#validate' do
+    {
+      "127.0.0.1:1234" => {:host => "127.0.0.1", :port => 1234},
+      "82.31.1.3:9800" => {:host => "82.31.1.3", :port => 9800},
+      "foo.com:1234"   => {:host => "foo.com",   :port => 1234},
+      "foo-bar-domain.com:9800" => {:host => "foo-bar-domain.com", :port => 9800},
+      "[::1]:1234" => {:host => "::1", :port => 1234},
+      "[2001:db8:3333:4444:5555:6666:7777:8888]:9800" => {:host => "2001:db8:3333:4444:5555:6666:7777:8888", :port => 9800},
+      "[2001:db8:3333::7777:8888]:9800" => {:host => "2001:db8:3333::7777:8888", :port => 9800},
+      "[::ffff:93.184.216.34]:1023" => {:host => "::ffff:93.184.216.34", :port => 1023},
+
+      "127.0.0.1" => {:host => "127.0.0.1", :port => nil},
+      "82.31.1.3" => {:host => "82.31.1.3", :port => nil},
+      "foo.com"   => {:host => "foo.com",   :port => nil},
+      "foo-bar-domain.com" => {:host => "foo-bar-domain.com", :port => nil},
+      "[::1]" => {:host => "::1", :port => nil},
+      "[2001:db8:3333:4444:5555:6666:7777:8888]" => {:host => "2001:db8:3333:4444:5555:6666:7777:8888", :port => nil},
+      "[2001:db8:3333::7777:8888]" => {:host => "2001:db8:3333::7777:8888", :port => nil},
+      "[::ffff:93.184.216.34]" => {:host => "::ffff:93.184.216.34", :port => nil},
+    }.each do |candidate, expected_result|
+      context "valid input `#{candidate.inspect}`" do
+        it "coerces the result to a host/port struct `#{expected_result}`" do
+          is_valid_result, coerced_or_error = described_class.validate([candidate])
+          failure = is_valid_result ? nil : coerced_or_error
+          coerced = is_valid_result ? coerced_or_error : nil
+
+          aggregate_failures do
+            expect(is_valid_result).to be true
+            expect(failure).to be_nil # makes spec failure output useful
+          end
+          expect(coerced).to have_attributes(expected_result.to_h)
+        end
+      end
+    end
+
+    [
+      "not an address",
+      "http://example.com:1234",
+      "tcp://example.com",
+      "http://example.com:1234/v1/this",
+      "",
+      ":1234", # port without host
+      "::1", # bare ipv6
+      "2001:db8:3333:4444:5555:6666:7777:8888",
+      "2001:db8:3333::7777:8888",
+      "[1:2:3:4:5:6::7:8:9:a:b:c]", # invalid compressed hex ipv6 form
+      "[::ffff:258.512.768.999]", # invalid compressed hex4dec ipv6 form
+    ].each do |candidate|
+      context "invalid input `#{candidate.inspect}`" do
+        it "reports the input as invalid" do
+          is_valid_result, coerced_or_error = described_class.validate([candidate])
+          failure = is_valid_result ? nil : coerced_or_error
+          coerced = is_valid_result ? coerced_or_error : nil
+
+          aggregate_failures do
+            expect(is_valid_result).to be false
+            expect(coerced).to be_nil # makes spec failure output useful
+          end
+          expect(failure).to_not be_nil
+        end
+      end
+    end
+  end
+end

--- a/spec/logstash/plugin_mixins/validator_support/required_host_optional_port_validation_adapter_spec.rb
+++ b/spec/logstash/plugin_mixins/validator_support/required_host_optional_port_validation_adapter_spec.rb
@@ -55,6 +55,7 @@ describe LogStash::PluginMixins::ValidatorSupport::RequiredHostOptionalPortValid
       "2001:db8:3333::7777:8888",
       "[1:2:3:4:5:6::7:8:9:a:b:c]", # invalid compressed hex ipv6 form
       "[::ffff:258.512.768.999]", # invalid compressed hex4dec ipv6 form
+      "example.com:98000",
     ].each do |candidate|
       context "invalid input `#{candidate.inspect}`" do
         it "reports the input as invalid" do


### PR DESCRIPTION
### What does this PR do?
It adds a validator for <host:port> pair where port is optional, default port can be applied.

- Closes #3 